### PR TITLE
fix: reliable external $ref loading, HTTP errors, and package main

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-transformer",
   "version": "0.11.0",
   "description": "Transforms OpenAPI Schemas to other formats like MarkDown and PlantUML",
-  "main": "index.js",
+  "main": "src/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/armand-janssen/openapi-transformer"

--- a/src/cli.js
+++ b/src/cli.js
@@ -53,5 +53,8 @@ if (!program.args.length || (program.plantuml == null && program.markdown == nul
     }
 
     if (verbose) console.log('Finished rendering documentation!');
-  })();
+  })().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,13 @@ const utils = require('./utils');
 
 const allLoadedFiles = [];
 
+function resolveReferencedPath(basePath, referencedFile) {
+  if (basePath.startsWith('http')) {
+    return new URL(referencedFile, basePath).href;
+  }
+  return path.join(basePath, referencedFile);
+}
+
 async function loadUrl(url) {
   return new Promise((resolve, reject) => {
     const httpLib = url.startsWith('https') ? https : http;
@@ -22,6 +29,11 @@ async function loadUrl(url) {
       });
 
       res.on('end', () => {
+        if (res.statusCode < 200 || res.statusCode >= 300) {
+          const snippet = data.length > 200 ? `${data.slice(0, 200)}…` : data;
+          reject(new Error(`HTTP ${res.statusCode} ${res.statusMessage || ''} for ${url}${snippet ? `: ${snippet}` : ''}`));
+          return;
+        }
         res.body = data;
         resolve(res);
       });
@@ -35,7 +47,11 @@ async function loadUrl(url) {
   });
 }
 
-async function loadYamlFile(fileOrUrl, verbose) {
+async function loadYamlFile(fileOrUrl, verbose, nested = false) {
+  if (!nested) {
+    allLoadedFiles.length = 0;
+  }
+
   if (allLoadedFiles.includes(fileOrUrl)) {
     if (verbose) console.log(`already loaded :: ${fileOrUrl}; skipping`);
     return [];
@@ -62,8 +78,8 @@ async function loadYamlFile(fileOrUrl, verbose) {
   allLoadedFiles.push(fileOrUrl);
   if (verbose) console.log(`loaded files :: ${allLoadedFiles}`);
 
-  if ((myYaml.components !== undefined && myYaml.components.schemas !== undefined) ||
-      myYaml.definitions !== undefined) {
+  if ((myYaml.components !== undefined && myYaml.components.schemas !== undefined)
+      || myYaml.definitions !== undefined) {
     let { schemas } = myYaml.components || {};
     if (!schemas) {
       schemas = myYaml.definitions;
@@ -74,15 +90,14 @@ async function loadYamlFile(fileOrUrl, verbose) {
     utils.mergeObjects(parsedSchemas, allParsedSchemas);
 
     if (referencedFiles !== undefined && referencedFiles.length > 0) {
-      referencedFiles.forEach(async (referencedFile) => {
-        const referencedParsedSchemas = await loadYamlFile(`${basePath}/${referencedFile}`, verbose);
+      await Promise.all(referencedFiles.map(async (referencedFile) => {
+        const nextPath = resolveReferencedPath(basePath, referencedFile);
+        const referencedParsedSchemas = await loadYamlFile(nextPath, verbose, true);
 
         utils.mergeObjects(referencedParsedSchemas, allParsedSchemas);
-      });
+      }));
     }
   }
-  // clean allLoadedFiles (for testing)
-  allLoadedFiles.length = 0;
   return allParsedSchemas;
 }
 module.exports.loadYamlFile = loadYamlFile;

--- a/src/property.js
+++ b/src/property.js
@@ -72,7 +72,7 @@ class Property {
       if (type == null && property.$ref != null) {
         // reference to other object, maybe in other file
         const reference = property.$ref;
-        const referencedFile = reference.match('^.*yaml');
+        const referencedFile = reference.match('^.*ya?ml');
 
         if (referencedFile != null && referencedFile.length === 1 && !referencedFiles.includes(referencedFile[0])) {
           referencedFiles.push(referencedFile[0]);
@@ -100,7 +100,7 @@ class Property {
               type += objectName;
 
               // is it a reference to an external file?
-              const referencedFile = item.match('^.*yaml');
+              const referencedFile = item.match('^.*ya?ml');
               if (referencedFile != null && referencedFile.length === 1 && !referencedFiles.includes(referencedFile[0])) {
                 referencedFiles.push(referencedFile[0]);
               }
@@ -120,7 +120,7 @@ class Property {
 
               type += objectName;
 
-              const referencedFile = reference.match('^.*yaml');
+              const referencedFile = reference.match('^.*ya?ml');
               if (referencedFile != null && referencedFile.length === 1 && !referencedFiles.includes(referencedFile[0])) {
                 referencedFiles.push(referencedFile[0]);
               }

--- a/src/utils.js
+++ b/src/utils.js
@@ -17,7 +17,7 @@ function addValueToArrayIfNotExists(array, value) {
 function addValuesOfArrayToOtherArrayIfNotExist(sourceArray, targetArray) {
   for (const sourceArrayIndex in sourceArray) {
     const value = sourceArray[sourceArrayIndex];
-    this.addValueToArrayIfNotExists(targetArray, value);
+    addValueToArrayIfNotExists(targetArray, value);
   }
 }
 

--- a/test/generatorHttpRefs.test.js
+++ b/test/generatorHttpRefs.test.js
@@ -32,7 +32,7 @@ describe('openApiGenerator - loadYamlFile - HTTP - 404', () => {
   it('Load error from HTTP.', async () => {
     try {
       await openApiGenerator.loadYamlFile('http://www.doesnotexist/swagger.json', true);
-      fail();
+      assert.fail('expected loadYamlFile to throw');
     } catch (error) {
       assert.isDefined(error);
       assert.equal(error.message, 'getaddrinfo ENOTFOUND www.doesnotexist');


### PR DESCRIPTION
## Summary

This PR fixes several correctness and packaging issues in `loadYamlFile` and related code. Callers that `await` loading a spec with external file `$ref`s now receive a **fully merged** schema map instead of racing the async work. Circular file references are handled using a **per-invocation** visited set. HTTP loads fail fast on non-2xx responses. The published `main` entry now points at the real library file.

## Root cause

- **Fire-and-forget `forEach(async …)`**: The outer async function returned before nested `loadYamlFile` calls finished, so `mergeObjects` often ran after the promise had already resolved.
- **`allLoadedFiles.length = 0` on every return**: The visited-file guard could not work correctly across nested loads (and defeated circular-$ref protection).
- **Wrong `package.json` `main`**: `index.js` does not exist at the repo root; consumers requiring the package would resolve the wrong path.
- **Test guard**: `fail()` in the HTTP error test was undefined; a missing throw would surface as `ReferenceError` instead of a failed assertion.

## Changes

| Area | Change |
|------|--------|
| `src/index.js` | `await Promise.all` over referenced files; `nested` flag and root-only clear of `allLoadedFiles`; `path.join` / `URL` for resolving refs; reject HTTP status outside 2xx in `loadUrl` |
| `package.json` | `"main": "src/index.js"` |
| `src/property.js` | Use `^.*ya?ml` for external file detection (match `schema.js`, support `.yml`) |
| `src/utils.js` | Call `addValueToArrayIfNotExists` directly (safe if the helper is ever destructured off exports) |
| `src/cli.js` | `.catch` on the async IIFE: log error and `process.exit(1)` |
| `test/generatorHttpRefs.test.js` | `assert.fail(...)` when a throw was expected |

## Testing

- `npm ci` then `npm test` (82 passing, nyc coverage report)
- Multi-file specs under `test/resources/generator*` (relative, transitive, circular refs) pass.

**Note:** `npm run lint` still reports pre-existing issues in other files; `src/index.js` was adjusted for `operator-linebreak` where needed.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * CLI now properly handles and reports errors, exiting with code 1 on failure
  * HTTP requests with non-2xx status codes are now treated as errors with detailed status information

* **New Features**
  * Added support for `.yml` file extension alongside `.yaml` for referenced schema files

* **Chores**
  * Updated package entry point configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->